### PR TITLE
fix: Add API base URL to production build config

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -18,7 +18,10 @@
       }
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "env": {
+        "EXPO_PUBLIC_API_BASE_URL": "https://backend-tau-jade-45.vercel.app"
+      }
     }
   },
   "submit": {


### PR DESCRIPTION
## Summary
- TestFlightビルドでバックエンドAPIに接続できない問題を修正
- `eas.json`の`production`プロファイルに`EXPO_PUBLIC_API_BASE_URL`環境変数を追加

## 問題
TestFlightでリリースしたアプリがバックエンドAPIに接続できず、デフォルトの`localhost:3000`にフォールバックしていた。

## 原因
Expo環境変数は**ビルド時に埋め込まれる**ため、EAS Buildの各プロファイルで明示的に設定する必要がある。`preview`プロファイルには設定されていたが、`production`プロファイルには未設定だった。

## 変更内容
```json
"production": {
  "autoIncrement": true,
  "env": {
    "EXPO_PUBLIC_API_BASE_URL": "https://backend-tau-jade-45.vercel.app"
  }
}
```

## Test plan
- [ ] `eas build --platform ios --profile production`でビルド作成
- [ ] TestFlightにsubmitして配信
- [ ] TestFlightアプリでAPIへの接続を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)